### PR TITLE
fix: pin transitive deps to patched versions (security)

### DIFF
--- a/package.json
+++ b/package.json
@@ -12,6 +12,11 @@
     "react-scripts": "^5.0.1",
     "web-vitals": "^2.1.3"
   },
+  "overrides": {
+    "@babel/plugin-transform-modules-systemjs": ">=7.29.7",
+    "fast-uri": ">=4.0.0",
+    "tmp": ">=0.2.7"
+  },
   "scripts": {
     "start": "react-scripts start",
     "build": "react-scripts build",


### PR DESCRIPTION
## Summary

Adds npm `overrides` to force patched versions of vulnerable transitive dependencies pulled in by `react-scripts` and its babel toolchain.

| Package | Vulnerable range | Fixed version | Advisory |
|---|---|---|---|
| `@babel/plugin-transform-modules-systemjs` | 7.12.0 – 7.29.0 | >=7.29.7 | GHSA-fv7c-fp4j-7gwp (arbitrary code generation, High) |
| `fast-uri` | <=3.1.1 | >=4.0.0 | GHSA-q3j6-qgpj-74h6, GHSA-v39h-62p7-jpjc (path traversal, host confusion, High) |
| `tmp` | <=0.2.5 | >=0.2.7 | GHSA-ph9p-34f9-6g65 (path traversal, High) |

After merging, run `npm install` to regenerate the lockfile with pinned versions.